### PR TITLE
Support more haskell syntaxes.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class Ghc(Linter):
 
     """Provides an interface to ghc."""
 
-    syntax = 'haskell'
+    syntax = ('haskell', 'literate haskell', 'haskell-sublimehaskell)
     cmd = ('ghc', '-fno-code', '-Wall', '-Wwarn', '-fno-helpful-errors')
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<warning>Warning:\s+)?(?P<message>.+)$'
     multiline = True


### PR DESCRIPTION
Per https://github.com/SublimeHaskell/SublimeHaskell/blob/master/fix_syntax.py#L26 the SublimeHaskell package renames the syntax. Adding these additions allows your plugin to work for people using SublimeHaskell.

Also, literate haskell ;)
