### PR TITLE
Ignore errors reported from imported files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,20 +18,6 @@ class Ghc(Linter):
 
     """Provides an interface to ghc."""
 
-    def split_match(self, match):
-        """Override to ignore errors reported in imported files."""
-        match, line, col, error, warning, message, near = (
-            super().split_match(match)
-        )
-
-        match_filename = basename(match.groupdict()['filename'])
-        linted_filename = basename(self.filename)
-
-        if match_filename != linted_filename:
-            return None, None, None, None, None, '', None
-
-        return match, line, col, error, warning, message, near
-
     syntax = ('haskell', 'haskell-sublimehaskell', 'literate haskell')
     cmd = ('ghc', '-fno-code', '-Wall', '-Wwarn', '-fno-helpful-errors')
     regex = (
@@ -50,3 +36,17 @@ class Ghc(Linter):
 
     # ghc writes errors to STDERR
     error_stream = util.STREAM_STDERR
+
+    def split_match(self, match):
+        """Override to ignore errors reported in imported files."""
+        match, line, col, error, warning, message, near = (
+            super().split_match(match)
+        )
+
+        match_filename = basename(match.groupdict()['filename'])
+        linted_filename = basename(self.filename)
+
+        if match_filename != linted_filename:
+            return None, None, None, None, None, '', None
+
+        return match, line, col, error, warning, message, near


### PR DESCRIPTION
Fixes #3.
I override `split_match` to compare linted files, and ignore errors where these differ.

I'd like @aparajita to review before merging.
