### PR TITLE
Fix for ghc 8

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -25,6 +25,11 @@ class Ghc(Linter):
     # ghc writes errors to STDERR
     error_stream = util.STREAM_STDERR
 
+    def finalize_cmd(self, cmd, context, **kwargs):
+        """Override to capture temporary filename."""
+        self.temp_file = context['temp_file']
+        return super().finalize_cmd(cmd, context, **kwargs)
+
     def split_match(self, match):
         """Override to ignore errors reported in imported files."""
         match, line, col, error, warning, message, near = (
@@ -32,7 +37,7 @@ class Ghc(Linter):
         )
 
         match_filename = basename(match.groupdict()['filename'])
-        linted_filename = basename(self.filename)
+        linted_filename = basename(self.temp_file)
 
         if match_filename != linted_filename:
             return None, None, None, None, None, '', None

--- a/linter.py
+++ b/linter.py
@@ -6,9 +6,11 @@ class Ghc(Linter):
     cmd = ('ghc', '-fno-code', '-Wall', '-Wwarn', '-fno-helpful-errors',
            '$temp_file')
     regex = (
-        r'^(?P<filename>.+):'
-        r'(?P<line>\d+):(?P<col>\d+):'
-        r'\s+(?P<warning>Warning:\s+)?(?P<message>.+)$'
+        r'\s*(?P<filename>.+):'
+        r'\s*(?P<line>\d+):(?P<col>\d+):'
+        r'\s*(?:(?P<warning>[Ww]arning):|(?P<error>[Ee]rror):)?'
+        r'\s*(?P<flag>\[-W[^\]]*\])?'
+        r'\s*(?P<message>.+?):?$'
     )
     multiline = True
     defaults = {
@@ -41,5 +43,8 @@ class Ghc(Linter):
 
         if match_filename != linted_filename:
             return None, None, None, None, None, '', None
+
+        if match.groupdict()['flag']:
+            message += " " + match.groupdict()['flag']
 
         return match, line, col, error, warning, message, near

--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,8 @@ from os.path import basename
 
 
 class Ghc(Linter):
-    cmd = ('ghc', '-fno-code', '-Wall', '-Wwarn', '-fno-helpful-errors')
+    cmd = ('ghc', '-fno-code', '-Wall', '-Wwarn', '-fno-helpful-errors',
+           '$temp_file')
     regex = (
         r'^(?P<filename>.+):'
         r'(?P<line>\d+):(?P<col>\d+):'


### PR DESCRIPTION
This actually fixes two problems:

1. The logic for ignoring errors in imported files was broken so all errors were being ignored.

2. The format of GHC's error messages has changed and the regex no longer matched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sublimelinter/sublimelinter-ghc/7)
<!-- Reviewable:end -->
